### PR TITLE
Fix quaternion left-multiplication as global rotation

### DIFF
--- a/Cube.h
+++ b/Cube.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct Cube {
+	FVector location;
+	FVector facing;
+	FRotator rotation;
+	FQuat orientation;
+	int indices[3];
+	int originalIndices[3];
+	Cube(): location(0, 0, 0), facing(1, 0, 0), rotation(0, 0, 0), indices{0}, originalIndices{0} {
+		orientation = FQuat(rotation);
+	}
+	// FString ToString() {
+	// 	return "<L:(" + location.ToString() + ") F:(" + facing.ToString() + " R:(" + rotation.ToString()
+	// 		+ ") [" + FString::FromInt(indices[0]) + "][" + FString::FromInt(indices[1])
+	// 		+ "][" + FString::FromInt(indices[2]) + "](" + FString::FromInt(originalIndices[0]) + "][" + FString::FromInt(originalIndices[1])
+	// 		+ "][" + FString::FromInt(originalIndices[2]) + "])>, ";
+	// }
+
+    FString ToString() const {
+        return FString::Printf(
+            TEXT("<L:(%.2f, %.2f, %.2f) F:(%.2f, %.2f, %.2f) R:(%.2f, %.2f, %.2f) [%d][%d][%d] ([%d][%d][%d])>, "),
+            location.X, location.Y, location.Z,
+            facing.X, facing.Y, facing.Z,
+            rotation.Pitch, rotation.Yaw, rotation.Roll,
+            indices[0], indices[1], indices[2],
+            originalIndices[0], originalIndices[1], originalIndices[2]
+        );
+    }
+
+	FString ToStringNormalized() const {
+        return FString::Printf(
+            TEXT("<L:(%.2f, %.2f, %.2f) F:(%.2f, %.2f, %.2f) R:(%.2f, %.2f, %.2f) [%d][%d][%d] ([%d][%d][%d])>, "),
+            abs(location.X), abs(location.Y), abs(location.Z),
+            abs(facing.X), abs(facing.Y), abs(facing.Z),
+            abs(rotation.Pitch), abs(rotation.Yaw), abs(rotation.Roll),
+            indices[0], indices[1], indices[2],
+            originalIndices[0], originalIndices[1], originalIndices[2]
+        );
+    }
+
+};

--- a/CubeAlgorithm.cpp
+++ b/CubeAlgorithm.cpp
@@ -169,6 +169,8 @@ void CubeAlgorithm::rotateLayer(int layer, int direction) {
         // Update the rotation (this is optional, based on your needs)
         // reverse?
         cube.rotation = (FQuat(cube.rotation) * QuatRotation).Rotator();
+        cube.orientation *= QuatRotation;
+        cube.orientation.Normalize();
         // cube.location = saveLocation;
         UE_LOG(LogTemp, Error, TEXT("cube after: %s"), *cube.ToString());
     }

--- a/CubeAlgorithm.cpp
+++ b/CubeAlgorithm.cpp
@@ -80,11 +80,12 @@ void CubeAlgorithm::init() {
 void CubeAlgorithm::populateRotators() {
     for (int layer = 0; layer < MAX_LAYERS; layer++) {
         if (layer >= 0 && layer < N) {
-            layerToRotator[layer] = FRotationMatrix(FRotator(0, 0, 90));
+            // layerToRotator[layer] = FRotationMatrix(FRotator(0, 0, 90));
+            layerToRotator[layer] = FRotator(0, 0, 90);
         } else if (layer >= N && layer < 2 * N) {
-            layerToRotator[layer] = FRotationMatrix(FRotator(90, 0, 0));
+            layerToRotator[layer] = FRotator(90, 0, 0);
         } else if (layer >= 2 * N && layer < 3 * N) {
-            layerToRotator[layer] = FRotationMatrix(FRotator(0, 90, 0));
+            layerToRotator[layer] = FRotator(0, 90, 0);
         }
     }
 }
@@ -103,7 +104,7 @@ FVector CubeAlgorithm::getRotationAxisForLayer(int layer) {
 }
 
 // void CubeAlgorithm::rotateLayer(int layer, int direction) {
-//     UE_LOG(LogTemp, Warning, TEXT("!!CubeAlgorithm::rotateLayer(%d, %d)"), layer, direction);
+//     UE_LOG(LogTemp, Warning, TEXT("!!CubeAlgorithm::rotateLayer OLD(%d, %d)"), layer, direction);
 //     std::vector<Cube> layerCubes = getLayer(layer);
 //     FVector indices;
 //     for (auto& cube : layerCubes) {
@@ -112,9 +113,10 @@ FVector CubeAlgorithm::getRotationAxisForLayer(int layer) {
 //         indices.Z = cube.indices[2] - 1;
 //         UE_LOG(LogTemp, Warning, TEXT("cube before: %s"), *cube.ToString());
 //         // UE_LOG(LogTemp, Warning, TEXT("indices before: %s"), *indices.ToString());
-//         cube.facing = layerToRotator[layer].TransformVector(cube.facing);
-//         indices = layerToRotator[layer].TransformVector(indices);
-//         cube.rotation += layerToRotator[layer].Rotator();
+//         // cube.facing = layerToRotator[layer].TransformVector(cube.facing);
+//         FMatrix matrix = FRotationMatrix(layerToRotator[layer]);
+//         indices = matrix.TransformVector(indices);
+//         cube.rotation += layerToRotator[layer];
 //         // cube.rotation = (FQuat(cube.rotation) * FQuat(layerToRotator[layer].Rotator())).Rotator();
 
 //         // UE_LOG(LogTemp, Warning, TEXT("%s"), *cube.ToString());
@@ -169,7 +171,7 @@ void CubeAlgorithm::rotateLayer(int layer, int direction) {
         // Update the rotation (this is optional, based on your needs)
         // reverse?
         cube.rotation = (FQuat(cube.rotation) * QuatRotation).Rotator();
-        cube.orientation *= QuatRotation;
+        cube.orientation = QuatRotation * cube.orientation;
         cube.orientation.Normalize();
         // cube.location = saveLocation;
         UE_LOG(LogTemp, Error, TEXT("cube after: %s"), *cube.ToString());

--- a/CubeAlgorithm.h
+++ b/CubeAlgorithm.h
@@ -12,9 +12,12 @@ struct Cube {
 	FVector location;
 	FVector facing;
 	FRotator rotation;
+	FQuat orientation;
 	int indices[3];
 	int originalIndices[3];
-	Cube(): location(0, 0, 0), facing(1, 0, 0), rotation(0, 0, 0), indices{0}, originalIndices{0} {}
+	Cube(): location(0, 0, 0), facing(1, 0, 0), rotation(0, 0, 0), indices{0}, originalIndices{0} {
+		orientation = FQuat(rotation);
+	}
 	// FString ToString() {
 	// 	return "<L:(" + location.ToString() + ") F:(" + facing.ToString() + " R:(" + rotation.ToString()
 	// 		+ ") [" + FString::FromInt(indices[0]) + "][" + FString::FromInt(indices[1])

--- a/CubeAlgorithm.h
+++ b/CubeAlgorithm.h
@@ -4,50 +4,12 @@
 
 #include "Utilities.h"
 #include "CoreMinimal.h"
+#include "Cube.h"
 
 #define N 3
 #define MAX_LAYERS N*N
 
-struct Cube {
-	FVector location;
-	FVector facing;
-	FRotator rotation;
-	FQuat orientation;
-	int indices[3];
-	int originalIndices[3];
-	Cube(): location(0, 0, 0), facing(1, 0, 0), rotation(0, 0, 0), indices{0}, originalIndices{0} {
-		orientation = FQuat(rotation);
-	}
-	// FString ToString() {
-	// 	return "<L:(" + location.ToString() + ") F:(" + facing.ToString() + " R:(" + rotation.ToString()
-	// 		+ ") [" + FString::FromInt(indices[0]) + "][" + FString::FromInt(indices[1])
-	// 		+ "][" + FString::FromInt(indices[2]) + "](" + FString::FromInt(originalIndices[0]) + "][" + FString::FromInt(originalIndices[1])
-	// 		+ "][" + FString::FromInt(originalIndices[2]) + "])>, ";
-	// }
 
-    FString ToString() const {
-        return FString::Printf(
-            TEXT("<L:(%.2f, %.2f, %.2f) F:(%.2f, %.2f, %.2f) R:(%.2f, %.2f, %.2f) [%d][%d][%d] ([%d][%d][%d])>, "),
-            location.X, location.Y, location.Z,
-            facing.X, facing.Y, facing.Z,
-            rotation.Pitch, rotation.Yaw, rotation.Roll,
-            indices[0], indices[1], indices[2],
-            originalIndices[0], originalIndices[1], originalIndices[2]
-        );
-    }
-
-	FString ToStringNormalized() const {
-        return FString::Printf(
-            TEXT("<L:(%.2f, %.2f, %.2f) F:(%.2f, %.2f, %.2f) R:(%.2f, %.2f, %.2f) [%d][%d][%d] ([%d][%d][%d])>, "),
-            abs(location.X), abs(location.Y), abs(location.Z),
-            abs(facing.X), abs(facing.Y), abs(facing.Z),
-            abs(rotation.Pitch), abs(rotation.Yaw), abs(rotation.Roll),
-            indices[0], indices[1], indices[2],
-            originalIndices[0], originalIndices[1], originalIndices[2]
-        );
-    }
-
-};
 
 /**
  * 
@@ -57,7 +19,7 @@ class CUBEALGO_API CubeAlgorithm
 private:
 	
 
-	FMatrix layerToRotator[MAX_LAYERS];
+	FRotator layerToRotator[MAX_LAYERS];
 	AActor* actor;
 	void populateRotators();
 	std::vector<Cube> getLayer(int layer);

--- a/CubeAlgorithmTester.cpp
+++ b/CubeAlgorithmTester.cpp
@@ -30,8 +30,8 @@ void ACubeAlgorithmTester::BeginPlay()
 	addAlgo(&algo1);
 	// testRotateLayer0();
 	// testQuatRotation();
-	// testQuatRotationRelative();
-	testQuatRotationEuclid();
+	testQuatRotationRelative();
+	// testQuatRotationEuclid();
 }
 
 // Called every frame
@@ -117,6 +117,8 @@ void ACubeAlgorithmTester::testQuatRotationRelative()
 	// Define the original rotations
 	FQuat QuatRotationAroundX = FQuat(FVector(1, 0, 0), PI / 2);
 	FQuat QuatRotationAroundY = FQuat(FVector(0, 1, 0), -PI / 2);
+	FQuat QuatRotationAroundZ = FQuat(FVector(0, 0, 1), -PI / 2);
+	FQuat QuatRotationAroundXY = (QuatRotationAroundX * QuatRotationAroundZ);
 
 	auto* defaultCube = spawnCube(FVector(0, 0, 500), facing, FRotator());
 	DrawActorFacingLine(defaultCube);
@@ -125,21 +127,37 @@ void ACubeAlgorithmTester::testQuatRotationRelative()
 	facing = defaultCube->GetActorForwardVector();
 
 	// First cube - rotated around X globally
-	auto* defaultCubeAroundX = spawnCube(FVector(0, 0, 1000), facing, QuatRotationAroundX.Rotator());
+	// auto* defaultCubeAroundX = spawnCube(FVector(0, 0, 1000), facing, QuatRotationAroundX.Rotator());
+	// DrawActorFacingLine(defaultCubeAroundX);
+	// UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundX: facing:%s"), *defaultCubeAroundX->GetActorForwardVector().ToString());
+
+	// auto* defaultCubeAroundXY = spawnCube(FVector(0, 0, 1500), facing, (QuatRotationAroundY * QuatRotationAroundX).Rotator());
+	// DrawActorFacingLine(defaultCubeAroundXY);
+	// UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXY->GetActorForwardVector().ToString());
+
+	// auto* defaultCubeAroundXYOther = spawnCube(FVector(0, 0, 2000), facing, (QuatRotationAroundZ * QuatRotationAroundY * QuatRotationAroundX).Rotator());
+	// DrawActorFacingLine(defaultCubeAroundXYOther);
+	// UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXYOther->GetActorForwardVector().ToString());
+
+	// auto* defaultCubeAroundXYOtherWay = spawnCube(FVector(0, 0, 2500), facing, (QuatRotationAroundZ * QuatRotationAroundXY).Rotator());
+	// DrawActorFacingLine(defaultCubeAroundXYOtherWay);
+	// UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXYOther->GetActorForwardVector().ToString());
+
+		auto* defaultCubeAroundX = spawnCube(FVector(0, 0, 1000), facing, QuatRotationAroundZ.Rotator());
 	DrawActorFacingLine(defaultCubeAroundX);
 	UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundX: facing:%s"), *defaultCubeAroundX->GetActorForwardVector().ToString());
 
-	// To rotate the next cube around Y globally after X rotation,
-	// we must reset to the original facing before applying Y rotation.
-	FVector newFacingAfterX = QuatRotationAroundX.RotateVector(facing);
-	FQuat QuatRotationAroundYGlobal = FQuat(FVector(0, 1, 0), -PI / 2);
-	FVector finalFacing = QuatRotationAroundYGlobal.RotateVector(newFacingAfterX);
-	FRotator finalRotator = finalFacing.Rotation();
-
-	auto* defaultCubeAroundXY = spawnCube(FVector(0, 0, 1500), facing, finalRotator);
+	auto* defaultCubeAroundXY = spawnCube(FVector(0, 0, 1500), facing, (QuatRotationAroundX * QuatRotationAroundZ).Rotator());
 	DrawActorFacingLine(defaultCubeAroundXY);
 	UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXY->GetActorForwardVector().ToString());
-	UE_LOG(LogTemp, Warning, TEXT("facing: %s newFacingAfterX: %s finalFacing: %s "), *facing.ToString(), *newFacingAfterX.ToString(), *finalFacing.ToString());
+
+	auto* defaultCubeAroundXYOther = spawnCube(FVector(0, 0, 2000), facing, (QuatRotationAroundY * QuatRotationAroundX * QuatRotationAroundZ).Rotator());
+	DrawActorFacingLine(defaultCubeAroundXYOther);
+	UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXYOther->GetActorForwardVector().ToString());
+
+	auto* defaultCubeAroundXYOtherWay = spawnCube(FVector(0, 0, 2500), facing, (QuatRotationAroundY * QuatRotationAroundXY).Rotator());
+	DrawActorFacingLine(defaultCubeAroundXYOtherWay);
+	UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXYOther->GetActorForwardVector().ToString());
 
 }
 
@@ -156,11 +174,11 @@ void ACubeAlgorithmTester::testQuatRotationEuclid()
 	DrawActorFacingLine(defaultCubeAroundX);
 	UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundX: facing:%s"), *defaultCubeAroundX->GetActorForwardVector().ToString());
 
-	auto* defaultCubeAroundXY = spawnCube(FVector(0, 0, 1500), facing, FRotator(0, 0, 90) + FRotator(90, 0, 0));
+	auto* defaultCubeAroundXY = spawnCube(FVector(0, 0, 1500), facing, FRotator(0, 0, 90) + FRotator(0, 90, 0));
 	DrawActorFacingLine(defaultCubeAroundXY);
 	UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXY->GetActorForwardVector().ToString());
 
-	auto* defaultCubeAroundXYZ = spawnCube(FVector(0, 0, 2000), facing, FRotator(0, 0, 90) + FRotator(90, 0, 0) + FRotator(0, 90, 0));
+	auto* defaultCubeAroundXYZ = spawnCube(FVector(0, 0, 2000), facing, FRotator(0, 0, 90) + FRotator(0, 90, 0) + FRotator(90, 0, 0));
 	DrawActorFacingLine(defaultCubeAroundXYZ);
 	UE_LOG(LogTemp, Warning, TEXT("defaultCubeAroundXY: facing:%s"), *defaultCubeAroundXYZ->GetActorForwardVector().ToString());
 

--- a/CubeAlgorithmTester.cpp
+++ b/CubeAlgorithmTester.cpp
@@ -9,6 +9,14 @@ ACubeAlgorithmTester::ACubeAlgorithmTester()
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;
 
+	static ConstructorHelpers::FObjectFinder<UStaticMesh> MeshObj(CUBE_MESH);
+    if (MeshObj.Succeeded())
+    {
+        CubeMesh = MeshObj.Object;
+        UE_LOG(LogTemp, Warning, TEXT("MeshObj: SUCCEEDED!"));
+    } else {
+		UE_LOG(LogTemp, Warning, TEXT("MeshObj: FAILED"));
+	}
 }
 
 // Called when the game starts or when spawned
@@ -21,6 +29,9 @@ void ACubeAlgorithmTester::BeginPlay()
 	
 	addAlgo(&algo1);
 	testRotateLayer0();
+	testQuatRotation();
+
+	spawnCube();
 	
 }
 
@@ -44,4 +55,38 @@ void ACubeAlgorithmTester::testRotateLayer0()
 		UE_LOG(LogTemp, Warning, TEXT("%s"), *algo->ToString());
 	}
 	UE_LOG(LogTemp, Warning, TEXT("ACubeAlgorithmTester::testRotateLayer0 stop"));	
+}
+
+void ACubeAlgorithmTester::testQuatRotation()
+{
+	FVector vectorToRotate = FVector(1, 0, 0);
+	FVector RotationAxis(1, 0, 0);
+	double RotationDegreesRadians = PI / 2;
+	FQuat QuatRotation = FQuat(RotationAxis, RotationDegreesRadians);
+	FVector rotatedVector = QuatRotation.RotateVector(vectorToRotate);
+	UE_LOG(LogTemp, Warning, TEXT("rotatedVector: %s"), *rotatedVector.ToString());
+
+	FRotator rotation = FRotator(0, 0, 0);
+	FRotator newRotation = (FQuat(rotation) * QuatRotation).Rotator();
+	UE_LOG(LogTemp, Display, TEXT("newRotation: %s"), *newRotation.ToString());
+}
+
+ACubeActor* ACubeAlgorithmTester::spawnCube(FVector location, FVector facing, FRotator rotation)
+{
+	FActorSpawnParameters SpawnParams;
+	SpawnParams.Owner = this;
+	SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+	ACubeActor* NewCube = GetWorld()->SpawnActor<ACubeActor>(ACubeActor::StaticClass(), location, FRotator::ZeroRotator, SpawnParams);
+
+	if (!NewCube || !NewCube->GetStaticMeshComponent())
+	{
+		UE_LOG(LogTemp, Error, TEXT("ACubeAlgorithmTester::spawnCube failed!"));
+		return nullptr;
+	}
+	NewCube->StartLocation = location;
+	NewCube->CubeEdgeLength = CUBE_EDGE_LENGTH;
+	NewCube->GetStaticMeshComponent()->SetStaticMesh(CubeMesh);  // Referencing CubeMesh here
+	NewCube->GetStaticMeshComponent()->SetMobility(EComponentMobility::Movable);  // Set mobility to Movable
+	NewCube->SetActorRotation(rotation);
+	return NewCube;
 }

--- a/CubeAlgorithmTester.h
+++ b/CubeAlgorithmTester.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "CubeAlgorithm.h"
+#include "CubeActor.h"
+#include "RubiksCubeActor.h"
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "CubeAlgorithmTester.generated.h"
@@ -17,6 +19,9 @@ public:
 	ACubeAlgorithmTester();
 	TArray<CubeAlgorithm*> algos = {};
 
+	UPROPERTY(EditAnywhere)
+    UStaticMesh* CubeMesh;
+
 protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
@@ -26,6 +31,8 @@ public:
 	virtual void Tick(float DeltaTime) override;
 	void addAlgo(CubeAlgorithm* algo);
 	void testRotateLayer0();
+	void testQuatRotation();
+	ACubeActor* spawnCube(FVector location=FVector(0, 0, 0), FVector facing=FVector(1, 0 , 0), FRotator rotation=FRotator(0, 0, 0));
 
 
 };

--- a/CubeAlgorithmTester.h
+++ b/CubeAlgorithmTester.h
@@ -32,7 +32,11 @@ public:
 	void addAlgo(CubeAlgorithm* algo);
 	void testRotateLayer0();
 	void testQuatRotation();
+	void testQuatRotationRelative();
+	void testQuatRotationEuclid();
+
 	ACubeActor* spawnCube(FVector location=FVector(0, 0, 0), FVector facing=FVector(1, 0 , 0), FRotator rotation=FRotator(0, 0, 0));
+	void DrawActorFacingLine(AStaticMeshActor *actor);
 
 
 };

--- a/RubiksCubeActor.cpp
+++ b/RubiksCubeActor.cpp
@@ -95,7 +95,8 @@ void ARubiksCubeActor::BeginPlay()
                     NewCube->CubeEdgeLength = CubeEdgeLength;
                     NewCube->GetStaticMeshComponent()->SetStaticMesh(CubeMesh);  // Referencing CubeMesh here
                     NewCube->GetStaticMeshComponent()->SetMobility(EComponentMobility::Movable);  // Set mobility to Movable
-					NewCube->SetActorRotation(algo.cubes[i][j][k].rotation);
+					// NewCube->SetActorRotation(algo.cubes[i][j][k].rotation);
+                    NewCube->SetActorRotation(algo.cubes[i][j][k].orientation.Rotator());
 
                     NewCube->SetOriginalIndices(algo.cubes[i][j][k].originalIndices[0],
                         algo.cubes[i][j][k].originalIndices[1],

--- a/RubiksCubeActor.h
+++ b/RubiksCubeActor.h
@@ -14,6 +14,8 @@
 
 #define CUBE_MESH TEXT("StaticMesh'/Game/SM_RubiksCube.SM_RubiksCube'")
 
+#define CUBE_EDGE_LENGTH 210.0f
+
 UCLASS()
 class CUBEALGO_API ARubiksCubeActor : public AActor
 {
@@ -37,7 +39,7 @@ public:
 
     // Cube edge length constant
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Rubik's Cube")
-    float CubeEdgeLength = 210.0f; // Adjust size as needed
+    float CubeEdgeLength = CUBE_EDGE_LENGTH; // Adjust size as needed
 
 	UPROPERTY(EditAnywhere)
 	FVector StartLocation;


### PR DESCRIPTION
Quaternion multiplication is non-commutative, with the practical implication that left-multiplication SecondQuaternion * FirstQuaternion applies the second rotation with respect to global axes, and FirstQuaternion * SecondQuaternion applies the second rotation with respect to local axis after first rotation.